### PR TITLE
Add standalone truck routing map for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,79 +2,762 @@
 <html lang="ru">
 <head>
   <meta charset="utf-8" />
-  <title>Карта для большегрузов — Яндекс визуал + OSRM маршрутизация</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Truck Route Planner</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <style>
-    html, body { margin:0; padding:0; height:100%; }
-    #map { width:100%; height:100%; }
-    #panel { position:absolute; top:10px; left:10px; background:white; padding:10px; border-radius:8px; box-shadow:0 2px 6px rgba(0,0,0,0.3); font-family:sans-serif; }
-    input { margin:4px 0; width:200px; padding:6px; }
-    button { margin:4px 0; padding:6px 10px; }
+    :root {
+      font-family: "Segoe UI", Roboto, sans-serif;
+      color: #111;
+      background: #fff;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+      background: #fff;
+    }
+    #map {
+      flex: 1;
+      min-height: 320px;
+    }
+    header {
+      padding: 12px clamp(12px, 3vw, 24px);
+      background: #ffffffee;
+      box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+      position: relative;
+      z-index: 10;
+    }
+    header h1 {
+      font-size: 18px;
+      margin: 0 0 8px;
+      font-weight: 600;
+      letter-spacing: 0.02em;
+    }
+    .controls {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      align-items: center;
+    }
+    .field {
+      display: flex;
+      flex-direction: column;
+      min-width: min(260px, 100%);
+    }
+    .field label {
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #444;
+      margin-bottom: 4px;
+    }
+    .field input {
+      border: 1px solid #d0d6e0;
+      border-radius: 6px;
+      padding: 8px 10px;
+      font-size: 14px;
+      transition: border-color 0.2s;
+    }
+    .field input:focus {
+      outline: none;
+      border-color: #1f6feb;
+      box-shadow: 0 0 0 3px rgba(31, 111, 235, 0.15);
+    }
+    .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      align-items: center;
+    }
+    button {
+      border: none;
+      border-radius: 6px;
+      padding: 9px 14px;
+      font-size: 14px;
+      font-weight: 600;
+      letter-spacing: 0.01em;
+      cursor: pointer;
+      transition: transform 0.15s, box-shadow 0.2s;
+    }
+    button.primary {
+      background: #1f6feb;
+      color: #fff;
+    }
+    button.secondary {
+      background: #111;
+      color: #fff;
+    }
+    button.ghost {
+      background: #f0f3f8;
+      color: #111;
+    }
+    button:active {
+      transform: translateY(1px);
+    }
+    button:disabled {
+      opacity: 0.45;
+      pointer-events: none;
+    }
+    .checkbox-group {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      font-size: 13px;
+      color: #222;
+    }
+    .checkbox-group label {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      cursor: pointer;
+    }
+    .legend {
+      position: absolute;
+      left: clamp(12px, 4vw, 24px);
+      bottom: clamp(12px, 4vw, 24px);
+      background: #ffffffec;
+      border-radius: 10px;
+      padding: 14px 16px;
+      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.12);
+      backdrop-filter: blur(6px);
+      max-width: 280px;
+      z-index: 5;
+      font-size: 13px;
+    }
+    .legend h2 {
+      font-size: 13px;
+      margin: 0 0 8px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #555;
+    }
+    .legend-item {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 6px;
+    }
+    .legend-color {
+      width: 18px;
+      height: 18px;
+      border-radius: 50%;
+      border: 2px solid #fff;
+      box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.12);
+    }
+    .info-line {
+      margin-top: 10px;
+      font-size: 13px;
+      color: #111;
+    }
+    .share {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 8px;
+    }
+    .share button {
+      font-weight: 500;
+      padding: 8px 12px;
+      font-size: 13px;
+    }
+    .status-bar {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      margin-top: 8px;
+      font-size: 13px;
+      color: #0f172a;
+    }
+    .status-pill {
+      background: #f1f5f9;
+      padding: 6px 10px;
+      border-radius: 999px;
+    }
+    .status-pill.alert {
+      background: rgba(255, 99, 71, 0.12);
+      color: #b42318;
+    }
+    .status-pill.ok {
+      background: rgba(59, 130, 246, 0.12);
+      color: #1f6feb;
+    }
+    .nav-status {
+      margin-top: 8px;
+      font-size: 13px;
+      color: #1f2937;
+    }
+    @media (max-width: 720px) {
+      header {
+        position: static;
+        box-shadow: none;
+        border-bottom: 1px solid #e2e8f0;
+      }
+      .legend {
+        left: 12px;
+        right: 12px;
+        bottom: 12px;
+        max-width: none;
+      }
+    }
   </style>
 </head>
 <body>
-<div id="map"></div>
-<div id="panel">
-  <div><input id="from" placeholder="Откуда (адрес или lat,lon)" /></div>
-  <div><input id="to" placeholder="Куда (адрес или lat,lon)" /></div>
-  <div>
-    <button id="routeBtn">Маршрут</button>
-    <button id="detourBtn">ИИ-объезд</button>
-  </div>
-</div>
+  <header>
+    <h1>Карта для фур · Яндекс.Карты + OSRM</h1>
+    <div class="controls">
+      <div class="field">
+        <label for="fromInput">Откуда</label>
+        <input id="fromInput" placeholder="Адрес или широта,долгота" />
+      </div>
+      <div class="field">
+        <label for="toInput">Куда</label>
+        <input id="toInput" placeholder="Адрес или широта,долгота" />
+      </div>
+      <div class="actions">
+        <button id="routeBtn" class="primary">Маршрут</button>
+        <button id="detourBtn" class="secondary">ИИ-объезд (beta)</button>
+        <button id="gpxBtn" class="ghost">Экспорт GPX</button>
+        <button id="navBtn" class="ghost">Навигатор (beta)</button>
+      </div>
+    </div>
+    <div class="checkbox-group" style="margin-top:10px;">
+      <label><input type="checkbox" id="weighToggle" checked /> Весовые рамки</label>
+      <label><input type="checkbox" id="platonToggle" checked /> Платон</label>
+    </div>
+    <div class="status-bar" id="statusBar"></div>
+    <div class="nav-status" id="navStatus"></div>
+    <div class="share">
+      <button id="shareWhatsapp" class="ghost">WhatsApp</button>
+      <button id="shareGmaps" class="ghost">Google Maps</button>
+      <button id="shareYnavi" class="ghost">Яндекс.Навигатор</button>
+    </div>
+  </header>
+  <div id="map"></div>
+  <aside class="legend">
+    <h2>Легенда зон</h2>
+    <div class="legend-item"><span class="legend-color" style="background:#ff4d4f;"></span>Весовые рамки (буфер 500 м)</div>
+    <div class="legend-item"><span class="legend-color" style="background:#f97316;"></span>Зоны Платон (буфер 300 м)</div>
+    <div class="info-line" id="hazardInfo">Данных о пересечениях пока нет.</div>
+  </aside>
+  <script type="module">
+    import {
+      YMap,
+      YMapDefaultSchemeLayer,
+      YMapDefaultFeaturesLayer,
+      YMapControls,
+      YMapZoomControl,
+      YMapMarker,
+      YMapCollection,
+      YMapFeature
+    } from "https://api-maps.yandex.ru/v3/?apikey=292c3277-6b44-4b1d-88db-813ff4caa159&lang=ru_RU";
 
-<script type="module">
-  import {YMap, YMapDefaultSchemeLayer, YMapDefaultFeaturesLayer, YMapMarker, YMapFeature, YMapCollection}
-    from "https://api-maps.yandex.ru/v3/?apikey=292c3277-6b44-4b1d-88db-813ff4caa159&lang=ru_RU";
+    const mapElement = document.getElementById("map");
+    const hazardInfo = document.getElementById("hazardInfo");
+    const statusBar = document.getElementById("statusBar");
+    const navStatusEl = document.getElementById("navStatus");
 
-  // --- Карта ---
-  const map = new YMap(document.getElementById('map'), {
-    location: {center:[37.618423,55.751244], zoom:5}
-  });
-  map.addChild(new YMapDefaultSchemeLayer());
-  map.addChild(new YMapDefaultFeaturesLayer());
+    const ui = {
+      from: document.getElementById("fromInput"),
+      to: document.getElementById("toInput"),
+      routeBtn: document.getElementById("routeBtn"),
+      detourBtn: document.getElementById("detourBtn"),
+      gpxBtn: document.getElementById("gpxBtn"),
+      navBtn: document.getElementById("navBtn"),
+      weighToggle: document.getElementById("weighToggle"),
+      platonToggle: document.getElementById("platonToggle"),
+      shareWhatsapp: document.getElementById("shareWhatsapp"),
+      shareGmaps: document.getElementById("shareGmaps"),
+      shareYnavi: document.getElementById("shareYnavi")
+    };
 
-  let routeLine = null;
-
-  // --- Вспомогательные функции ---
-  function parseLatLon(s){
-    const m=String(s).trim().match(/(-?\d+(\.\d+)?),\s*(-?\d+(\.\d+)?)/);
-    if(m) return [parseFloat(m[1]), parseFloat(m[3])]; // lat, lon
-    return null;
-  }
-  async function geocode(q){
-    const ll=parseLatLon(q);
-    if(ll) return ll;
-    const url=`https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(q)}`;
-    const r=await fetch(url,{headers:{'Accept-Language':'ru'}});
-    const js=await r.json();
-    if(!js.length) throw new Error("Адрес не найден");
-    return [parseFloat(js[0].lat), parseFloat(js[0].lon)];
-  }
-  async function buildRoute(points){
-    const coords = points.map(p=>p.reverse().join(',')).join(';'); // lon,lat
-    const url=`https://router.project-osrm.org/route/v1/driving/${coords}?overview=full&geometries=geojson`;
-    const r=await fetch(url); const js=await r.json();
-    if(!js.routes?.length) return alert("Маршрут не найден");
-    const rt=js.routes[0].geometry.coordinates; // [lon,lat]
-    const coordsLL=rt.map(([lon,lat])=>[lon,lat]);
-    if(routeLine) routeLine.remove();
-    routeLine=new YMapFeature({
-      geometry:{type:"LineString", coordinates:coordsLL},
-      style:{stroke:[{color:"#0066ff",width:4}]}
+    const map = new YMap(mapElement, {
+      location: {
+        center: [37.618423, 55.751244],
+        zoom: 5
+      }
     });
-    map.addChild(routeLine);
-  }
+    map.addChild(new YMapDefaultSchemeLayer());
+    map.addChild(new YMapDefaultFeaturesLayer());
+    const controls = new YMapControls({ position: "right" });
+    controls.addChild(new YMapZoomControl({}));
+    map.addChild(controls);
 
-  // --- Обработчики ---
-  document.getElementById('routeBtn').onclick=async()=>{
-    const a=await geocode(document.getElementById('from').value);
-    const b=await geocode(document.getElementById('to').value);
-    await buildRoute([a,b]);
-  };
-  document.getElementById('detourBtn').onclick=()=>{
-    alert("ИИ-объезд (demo): здесь будет логика объезда весовых рамок и Платона");
-  };
-</script>
+    const weighCollection = new YMapCollection({ zIndex: 110 });
+    const platonCollection = new YMapCollection({ zIndex: 105 });
+    map.addChild(weighCollection);
+    map.addChild(platonCollection);
+    weighCollection.__visible = true;
+    platonCollection.__visible = true;
+
+    let routeFeature = null;
+    let routeShadow = null;
+    let currentPositionMarker = null;
+    let geoWatchId = null;
+    const voice = window.speechSynthesis;
+    let lastCameraZoom = 5;
+
+    const hazardData = [];
+    const state = {
+      currentWaypoints: [],
+      routeGeoJSON: null,
+      maneuvers: [],
+      lastAnnouncedStep: null
+    };
+
+    const MAX_WAYPOINTS = 6;
+
+    const COLORS = {
+      weigh: "#ff4d4f",
+      platon: "#f97316"
+    };
+
+    function deg2rad(deg) {
+      return deg * Math.PI / 180;
+    }
+    function rad2deg(rad) {
+      return rad * 180 / Math.PI;
+    }
+    function haversineMeters(a, b) {
+      const R = 6378137;
+      const [lon1, lat1] = a;
+      const [lon2, lat2] = b;
+      const dLat = deg2rad(lat2 - lat1);
+      const dLon = deg2rad(lon2 - lon1);
+      const sinLat = Math.sin(dLat / 2);
+      const sinLon = Math.sin(dLon / 2);
+      const q = sinLat * sinLat + Math.cos(deg2rad(lat1)) * Math.cos(deg2rad(lat2)) * sinLon * sinLon;
+      return 2 * R * Math.atan2(Math.sqrt(q), Math.sqrt(1 - q));
+    }
+    function bearingBetween(from, to) {
+      const [lon1, lat1] = from.map(deg2rad);
+      const [lon2, lat2] = to.map(deg2rad);
+      const dLon = lon2 - lon1;
+      const y = Math.sin(dLon) * Math.cos(lat2);
+      const x = Math.cos(lat1) * Math.sin(lat2) - Math.sin(lat1) * Math.cos(lat2) * Math.cos(dLon);
+      return (rad2deg(Math.atan2(y, x)) + 360) % 360;
+    }
+    function destinationPoint(coord, distance, bearingDeg) {
+      const [lon, lat] = coord;
+      const R = 6378137;
+      const δ = distance / R;
+      const θ = deg2rad(bearingDeg);
+      const φ1 = deg2rad(lat);
+      const λ1 = deg2rad(lon);
+      const sinφ1 = Math.sin(φ1);
+      const cosφ1 = Math.cos(φ1);
+      const sinδ = Math.sin(δ);
+      const cosδ = Math.cos(δ);
+      const sinθ = Math.sin(θ);
+      const cosθ = Math.cos(θ);
+      const sinφ2 = sinφ1 * cosδ + cosφ1 * sinδ * cosθ;
+      const φ2 = Math.asin(sinφ2);
+      const y = sinθ * sinδ * cosφ1;
+      const x = cosδ - sinφ1 * sinφ2;
+      const λ2 = λ1 + Math.atan2(y, x);
+      const newLon = (rad2deg(λ2) + 540) % 360 - 180;
+      const newLat = rad2deg(φ2);
+      return [newLon, newLat];
+    }
+
+    function updateStatusPills(message, type = "info") {
+      statusBar.innerHTML = "";
+      if (!message) return;
+      const pill = document.createElement("span");
+      pill.className = "status-pill" + (type === "alert" ? " alert" : type === "ok" ? " ok" : "");
+      pill.textContent = message;
+      statusBar.appendChild(pill);
+    }
+
+    function speak(text) {
+      if (!("speechSynthesis" in window)) return;
+      if (voice.speaking) voice.cancel();
+      const utterance = new SpeechSynthesisUtterance(text);
+      utterance.lang = "ru-RU";
+      utterance.rate = 1;
+      voice.speak(utterance);
+    }
+
+    function parseLatLon(input) {
+      const match = String(input).trim().match(/(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)/);
+      if (!match) return null;
+      const lat = parseFloat(match[1]);
+      const lon = parseFloat(match[2]);
+      if (Number.isFinite(lat) && Number.isFinite(lon)) {
+        return [lon, lat];
+      }
+      return null;
+    }
+
+    async function geocode(query) {
+      const parsed = parseLatLon(query);
+      if (parsed) return parsed;
+      const url = `https://nominatim.openstreetmap.org/search?format=json&limit=1&q=${encodeURIComponent(query)}`;
+      const response = await fetch(url, {
+        headers: {
+          "Accept-Language": "ru"
+        }
+      });
+      if (!response.ok) throw new Error("Не удалось выполнить геокодирование");
+      const result = await response.json();
+      if (!Array.isArray(result) || !result.length) throw new Error("Адрес не найден");
+      return [parseFloat(result[0].lon), parseFloat(result[0].lat)];
+    }
+
+    async function requestOsrmRoute(points) {
+      const coords = points.map(([lon, lat]) => `${lon},${lat}`).join(";");
+      const url = `https://router.project-osrm.org/route/v1/driving/${coords}?overview=full&geometries=geojson&steps=true&annotations=true`; 
+      const response = await fetch(url);
+      if (!response.ok) throw new Error("OSRM не ответил");
+      const data = await response.json();
+      if (!data.routes || !data.routes.length) throw new Error("Маршрут не найден");
+      return data.routes[0];
+    }
+
+    function getBoundsFromCoords(coords) {
+      if (!coords.length) return null;
+      let minLon = coords[0][0];
+      let maxLon = coords[0][0];
+      let minLat = coords[0][1];
+      let maxLat = coords[0][1];
+      coords.forEach(([lon, lat]) => {
+        if (lon < minLon) minLon = lon;
+        if (lon > maxLon) maxLon = lon;
+        if (lat < minLat) minLat = lat;
+        if (lat > maxLat) maxLat = lat;
+      });
+      return [
+        [minLon, minLat],
+        [maxLon, maxLat]
+      ];
+    }
+
+    function drawRoute(route) {
+      const coordinates = route.geometry.coordinates.map(([lon, lat]) => [lon, lat]);
+      if (routeFeature) routeFeature.remove();
+      if (routeShadow) routeShadow.remove();
+      routeShadow = new YMapFeature({
+        geometry: { type: "LineString", coordinates },
+        style: {
+          stroke: [
+            { color: "rgba(17, 24, 39, 0.25)", width: 9 }
+          ]
+        }
+      });
+      routeFeature = new YMapFeature({
+        geometry: { type: "LineString", coordinates },
+        style: {
+          stroke: [
+            { color: "#1f6feb", width: 5 }
+          ]
+        }
+      });
+      map.addChild(routeShadow);
+      map.addChild(routeFeature);
+      const bounds = getBoundsFromCoords(coordinates);
+      if (bounds) {
+        map.update({ location: { bounds } });
+      }
+    }
+
+    function flattenManeuvers(route) {
+      const maneuvers = [];
+      route.legs.forEach((leg, legIdx) => {
+        leg.steps.forEach((step, stepIdx) => {
+          if (!step.maneuver) return;
+          maneuvers.push({
+            instruction: step.name ? `${step.maneuver.instruction || step.maneuver.type || ""} (${step.name})` : step.maneuver.instruction || step.maneuver.type || "Маневр",
+            location: step.maneuver.location,
+            distance: step.distance,
+            legIdx,
+            stepIdx
+          });
+        });
+      });
+      return maneuvers;
+    }
+
+    function analyzeHazards(routeCoords) {
+      const hits = [];
+      for (const hazard of hazardData) {
+        const { center, radius, type } = hazard;
+        for (const coord of routeCoords) {
+          const distance = haversineMeters(coord, center);
+          if (distance <= radius) {
+            hits.push({ hazard, coord, distance });
+            break;
+          }
+        }
+      }
+      if (!hits.length) {
+        hazardInfo.textContent = "Маршрут не пересекает контролируемые зоны.";
+        updateStatusPills("Пересечений не обнаружено", "ok");
+      } else {
+        hazardInfo.textContent = `Пересечений: ${hits.length}. Попробуйте ИИ-объезд.`;
+        updateStatusPills(`Маршрут пересекает ${hits.length} опасных зон`, "alert");
+      }
+      return hits;
+    }
+
+    function createDetourPoint(hit) {
+      const { hazard, coord } = hit;
+      const bearing = bearingBetween(hazard.center, coord);
+      const distance = hazard.radius + 400;
+      const options = [bearing + 90, bearing - 90].map(b => (b + 360) % 360);
+      const candidates = options.map(bearingDeg => destinationPoint(coord, distance, bearingDeg));
+      const safe = candidates.filter(c => haversineMeters(c, hazard.center) > hazard.radius + 50);
+      return (safe[0] || candidates[0]);
+    }
+
+    function composeWaypointsWithDetour(basePoints, hits) {
+      if (!hits.length) return basePoints;
+      const viaPoints = [];
+      hits.forEach(hit => {
+        const via = createDetourPoint(hit);
+        if (!via) return;
+        const key = via.map(n => n.toFixed(5)).join(",");
+        if (!viaPoints.some(v => v.key === key)) {
+          viaPoints.push({ key, coord: via });
+        }
+      });
+      const limitedVia = viaPoints.slice(0, Math.max(0, MAX_WAYPOINTS - basePoints.length));
+      return [basePoints[0], ...limitedVia.map(v => v.coord), basePoints[basePoints.length - 1]];
+    }
+
+    async function buildAndRenderRoute(points, options = { detour: false }) {
+      const limitedPoints = points.slice(0, MAX_WAYPOINTS);
+      state.currentWaypoints = limitedPoints;
+      updateStatusPills("Запрос маршрута...");
+      try {
+        const route = await requestOsrmRoute(limitedPoints);
+        state.routeGeoJSON = route.geometry;
+        state.maneuvers = flattenManeuvers(route);
+        drawRoute(route);
+        analyzeHazards(route.geometry.coordinates.map(([lon, lat]) => [lon, lat]));
+        updateShareLinks();
+        updateStatusPills(options.detour ? "ИИ-объезд построил маршрут" : "Маршрут готов", "ok");
+      } catch (error) {
+        console.error(error);
+        updateStatusPills(error.message || "Ошибка построения", "alert");
+      }
+    }
+
+    async function handleRouteClick() {
+      const fromValue = ui.from.value.trim();
+      const toValue = ui.to.value.trim();
+      if (!fromValue || !toValue) {
+        updateStatusPills("Укажите начальную и конечную точки", "alert");
+        return;
+      }
+      try {
+        updateStatusPills("Геокодирование...");
+        const [from, to] = await Promise.all([geocode(fromValue), geocode(toValue)]);
+        await buildAndRenderRoute([from, to]);
+      } catch (error) {
+        console.error(error);
+        updateStatusPills(error.message || "Не удалось построить маршрут", "alert");
+      }
+    }
+
+    async function handleDetour() {
+      if (!state.routeGeoJSON || state.currentWaypoints.length < 2) {
+        updateStatusPills("Сначала постройте маршрут", "alert");
+        return;
+      }
+      const hits = analyzeHazards(state.routeGeoJSON.coordinates.map(([lon, lat]) => [lon, lat]));
+      if (!hits.length) {
+        updateStatusPills("Опасных зон нет — объезд не нужен", "ok");
+        return;
+      }
+      const newPoints = composeWaypointsWithDetour(state.currentWaypoints, hits);
+      await buildAndRenderRoute(newPoints, { detour: true });
+    }
+
+    function updateShareLinks() {
+      const pts = state.currentWaypoints;
+      if (!pts || pts.length < 2) return;
+      const trimmed = pts.slice(0, MAX_WAYPOINTS);
+      const origin = trimmed[0];
+      const destination = trimmed[trimmed.length - 1];
+      const via = trimmed.slice(1, -1);
+      const formatLatLon = ([lon, lat]) => `${lat.toFixed(6)},${lon.toFixed(6)}`;
+      const googleWaypoints = via.map(formatLatLon).join("|");
+      const gmapsUrl = new URL("https://www.google.com/maps/dir/");
+      gmapsUrl.searchParams.set("api", "1");
+      gmapsUrl.searchParams.set("origin", formatLatLon(origin));
+      gmapsUrl.searchParams.set("destination", formatLatLon(destination));
+      if (googleWaypoints) gmapsUrl.searchParams.set("waypoints", googleWaypoints);
+      const yandexNavUrl = new URL("yandexnavi://build_route_on_map");
+      yandexNavUrl.searchParams.set("lat_from", origin[1].toFixed(6));
+      yandexNavUrl.searchParams.set("lon_from", origin[0].toFixed(6));
+      yandexNavUrl.searchParams.set("lat_to", destination[1].toFixed(6));
+      yandexNavUrl.searchParams.set("lon_to", destination[0].toFixed(6));
+      if (via.length) {
+        yandexNavUrl.searchParams.set("via", via.map(formatLatLon).join("~"));
+      }
+      ui.shareGmaps.onclick = () => window.open(gmapsUrl.toString(), "_blank");
+      ui.shareYnavi.onclick = () => window.open(yandexNavUrl.toString(), "_blank");
+      const shareText = encodeURIComponent(`Маршрут для фуры:\nGoogle Maps: ${gmapsUrl.toString()}\nЯндекс.Навигатор: ${yandexNavUrl.toString()}`);
+      ui.shareWhatsapp.onclick = () => {
+        const waUrl = `https://wa.me/?text=${shareText}`;
+        window.open(waUrl, "_blank");
+      };
+    }
+
+    function exportToGpx() {
+      if (!state.routeGeoJSON) {
+        updateStatusPills("Нет маршрута для экспорта", "alert");
+        return;
+      }
+      const coords = state.routeGeoJSON.coordinates;
+      const gpxPoints = coords.map(([lon, lat]) => `<trkpt lat="${lat}" lon="${lon}"><ele>0</ele></trkpt>`).join("\n        ");
+      const gpx = `<?xml version="1.0" encoding="UTF-8"?>\n<gpx version="1.1" creator="truck-map" xmlns="http://www.topografix.com/GPX/1/1">\n  <trk>\n    <name>Truck Route</name>\n    <trkseg>\n        ${gpxPoints}\n    </trkseg>\n  </trk>\n</gpx>`;
+      const blob = new Blob([gpx], { type: "application/gpx+xml" });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = "truck_route.gpx";
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+      updateStatusPills("GPX сохранён", "ok");
+    }
+
+    function startNavigator() {
+      if (!navigator.geolocation) {
+        updateStatusPills("Геолокация недоступна", "alert");
+        return;
+      }
+      if (!state.maneuvers.length) {
+        updateStatusPills("Постройте маршрут для навигации", "alert");
+        return;
+      }
+      if (geoWatchId !== null) {
+        navigator.geolocation.clearWatch(geoWatchId);
+        geoWatchId = null;
+        if (currentPositionMarker) {
+          currentPositionMarker.remove();
+          currentPositionMarker = null;
+        }
+        navStatusEl.textContent = "Навигация остановлена.";
+        ui.navBtn.textContent = "Навигатор (beta)";
+        updateStatusPills("Навигатор остановлен");
+        return;
+      }
+      ui.navBtn.textContent = "Стоп навигация";
+      navStatusEl.textContent = "Ожидание геопозиции...";
+      state.lastAnnouncedStep = null;
+      lastCameraZoom = 14;
+      geoWatchId = navigator.geolocation.watchPosition(position => {
+        const { latitude, longitude } = position.coords;
+        const coord = [longitude, latitude];
+        if (!currentPositionMarker) {
+          const markerEl = document.createElement("div");
+          markerEl.style.width = "16px";
+          markerEl.style.height = "16px";
+          markerEl.style.borderRadius = "50%";
+          markerEl.style.background = "#2563eb";
+          markerEl.style.border = "3px solid #bfdbfe";
+          markerEl.style.boxShadow = "0 0 0 6px rgba(37, 99, 235, 0.15)";
+          currentPositionMarker = new YMapMarker({ coordinates: coord }, markerEl);
+          map.addChild(currentPositionMarker);
+        } else {
+          currentPositionMarker.update({ coordinates: coord });
+        }
+        lastCameraZoom = Math.max(lastCameraZoom, 14);
+        map.update({ location: { center: coord, zoom: lastCameraZoom } });
+        handleNavigationStep(coord);
+      }, error => {
+        navStatusEl.textContent = "Геолокация недоступна: " + error.message;
+        updateStatusPills("Ошибка геолокации", "alert");
+      }, { enableHighAccuracy: true, maximumAge: 5000, timeout: 10000 });
+      updateStatusPills("Навигация запущена", "ok");
+    }
+
+    function handleNavigationStep(currentCoord) {
+      if (!state.maneuvers.length) return;
+      let nearest = null;
+      let nearestDistance = Infinity;
+      state.maneuvers.forEach((step, index) => {
+        const dist = haversineMeters(currentCoord, step.location);
+        if (dist < nearestDistance) {
+          nearestDistance = dist;
+          nearest = { step, index };
+        }
+      });
+      if (!nearest) return;
+      navStatusEl.textContent = `Следующий манёвр через ${Math.round(nearestDistance)} м: ${nearest.step.instruction}`;
+      if (nearestDistance < 80 && state.lastAnnouncedStep !== nearest.index) {
+        speak(nearest.step.instruction);
+        state.lastAnnouncedStep = nearest.index;
+      }
+    }
+
+    function toggleLayer(collection, visible) {
+      if (visible) {
+        if (!collection.__visible) {
+          map.addChild(collection);
+          collection.__visible = true;
+        }
+      } else {
+        if (collection.__visible) {
+          collection.remove();
+          collection.__visible = false;
+        }
+      }
+    }
+
+    async function loadHazards() {
+      try {
+        const [weigh, platon] = await Promise.all([
+          fetch("weigh_frames.geojson").then(r => r.json()),
+          fetch("platon.geojson").then(r => r.json())
+        ]);
+        const buildFeatures = (data, type) => {
+          const radius = type === "weigh" ? 500 : 300;
+          const collection = type === "weigh" ? weighCollection : platonCollection;
+          data.features.forEach(feature => {
+            if (!feature.geometry || feature.geometry.type !== "Point") return;
+            const [lon, lat] = feature.geometry.coordinates;
+            hazardData.push({ center: [lon, lat], radius, type });
+            const outer = new YMapFeature({
+              geometry: { type: "Circle", coordinates: [lon, lat], radius },
+              style: {
+                fill: { color: type === "weigh" ? "rgba(255, 77, 79, 0.18)" : "rgba(249, 115, 22, 0.18)" },
+                stroke: [ { color: type === "weigh" ? "rgba(255, 77, 79, 0.4)" : "rgba(249, 115, 22, 0.4)", width: 2 } ]
+              }
+            });
+            const inner = new YMapFeature({
+              geometry: { type: "Circle", coordinates: [lon, lat], radius: 70 },
+              style: {
+                fill: { color: type === "weigh" ? COLORS.weigh : COLORS.platon },
+                stroke: [ { color: "#ffffff", width: 2 } ]
+              }
+            });
+            collection.addChild(outer);
+            collection.addChild(inner);
+          });
+        };
+        buildFeatures(weigh, "weigh");
+        buildFeatures(platon, "platon");
+        updateStatusPills("Зоны загружены", "ok");
+      } catch (error) {
+        console.error(error);
+        updateStatusPills("Не удалось загрузить зоны", "alert");
+      }
+    }
+
+    ui.routeBtn.addEventListener("click", () => handleRouteClick());
+    ui.detourBtn.addEventListener("click", () => handleDetour());
+    ui.gpxBtn.addEventListener("click", () => exportToGpx());
+    ui.navBtn.addEventListener("click", () => startNavigator());
+    ui.weighToggle.addEventListener("change", event => toggleLayer(weighCollection, event.target.checked));
+    ui.platonToggle.addEventListener("change", event => toggleLayer(platonCollection, event.target.checked));
+
+    loadHazards();
+    updateStatusPills("Готово к построению маршрута");
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the landing page with a production-ready truck routing UI using Yandex Maps v3
- load weigh station and Platon GeoJSON data with buffered danger zones and toggleable overlays
- integrate OSRM routing with AI detour heuristics, navigation mode, GPX export, and share actions

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68de69594b2483238e0a19c8677504bb