### PR TITLE
Add standalone truck routing map with OSRM integration

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,344 +1,341 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="ru">
 <head>
   <meta charset="utf-8" />
-  <title>Карта для большегрузов — Яндекс (v2.1) + OSRM + объезд зон</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Маршруты для грузовиков</title>
   <style>
-    html,body { height:100%; margin:0; }
-    #app { display:grid; grid-template-rows:auto 1fr auto; height:100%; font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif; }
-    #toolbar { display:grid; grid-template-columns:1.2fr 1.2fr 120px 130px 130px 1fr; gap:8px; padding:10px; border-bottom:1px solid #eee; }
-    #map { width:100%; height:100%; }
-    #footer { display:flex; gap:8px; padding:10px; border-top:1px solid #eee; align-items:center; flex-wrap:wrap; }
-    .pill { padding:8px 10px; border:1px solid #ddd; border-radius:8px; min-width:0; }
-    .btn { padding:8px 12px; border:none; border-radius:8px; cursor:pointer; }
-    .btn-primary { background:#0b57d0; color:#fff; }
-    .btn-ghost { background:#f5f5f5; }
-    .chips { display:flex; gap:12px; align-items:center; }
-    .tag { font-size:12px; padding:2px 8px; background:#eef3ff; border:1px solid #d9e2ff; border-radius:999px; }
-    .legend { position:absolute; top:12px; right:12px; background:#fff; padding:8px 10px; border-radius:8px; box-shadow:0 2px 6px rgba(0,0,0,.15); font-size:13px; }
-    .legend b { display:block; margin-bottom:4px; }
-    .mute { color:#666; font-size:12px; }
-    .navpanel { position:absolute; left:12px; bottom:70px; background:#fff; border-radius:10px; box-shadow:0 2px 10px rgba(0,0,0,.15); padding:8px 10px; font-size:14px; min-width:240px; display:none; }
-    .navpanel b { display:block; margin-bottom:4px; }
+    html, body {
+      height: 100%;
+      margin: 0;
+      font-family: "Segoe UI", Roboto, sans-serif;
+      background: #fff;
+    }
+    #map {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+    }
+    .controls {
+      position: absolute;
+      top: 20px;
+      left: 20px;
+      display: grid;
+      gap: 8px;
+      padding: 16px;
+      background: rgba(255, 255, 255, 0.92);
+      box-shadow: 0 8px 18px rgba(0, 0, 0, 0.12);
+      border-radius: 12px;
+      z-index: 2000;
+      width: min(320px, calc(100vw - 40px));
+    }
+    .controls label {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      font-size: 13px;
+      color: #333;
+    }
+    .controls input {
+      padding: 10px 12px;
+      border: 1px solid #d0d7de;
+      border-radius: 8px;
+      font-size: 15px;
+    }
+    .controls button {
+      padding: 12px;
+      border: none;
+      border-radius: 8px;
+      background: #0a6bff;
+      color: #fff;
+      font-size: 15px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.2s ease;
+    }
+    .controls button:hover {
+      background: #0059d6;
+    }
+    .legend {
+      position: absolute;
+      top: 20px;
+      right: 20px;
+      padding: 14px 18px;
+      background: rgba(255, 255, 255, 0.92);
+      border-radius: 12px;
+      box-shadow: 0 8px 18px rgba(0, 0, 0, 0.12);
+      font-size: 13px;
+      line-height: 1.6;
+      z-index: 1500;
+    }
+    .legend .title {
+      font-weight: 700;
+      margin-bottom: 6px;
+    }
+    .legend-item {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .legend-dot {
+      width: 12px;
+      height: 12px;
+      border-radius: 50%;
+    }
+    .legend-dot.red { background: #ff3b30; }
+    .legend-dot.orange { background: #ff9500; }
+    .legend-line {
+      width: 18px;
+      height: 3px;
+      background: #0066ff;
+      border-radius: 3px;
+    }
+    .ymaps-suggest__container {
+      z-index: 4000 !important;
+    }
   </style>
-  <script src="https://api-maps.yandex.ru/2.1/?apikey=292c3277-6b44-4b1d-88db-813ff4caa159&lang=ru_RU"></script>
+  <script src="https://api-maps.yandex.ru/2.1/?apikey=YOUR_KEY_HERE&lang=ru_RU"></script>
 </head>
 <body>
-<div id="app">
-  <div id="toolbar">
-    <input id="from" class="pill" placeholder="Откуда (адрес или lat,lon)" />
-    <input id="to" class="pill" placeholder="Куда (адрес или lat,lon)" />
-    <button id="routeBtn" class="btn btn-primary">Маршрут</button>
-    <button id="detourBtn" class="btn btn-ghost" title="ИИ-объезд (beta)">ИИ-объезд</button>
-    <button id="gpxBtn" class="btn btn-ghost" title="Экспорт GPX">Экспорт GPX</button>
-    <div class="chips">
-      <label class="tag"><input type="checkbox" id="showFrames" checked/> Рамки</label>
-      <label class="tag"><input type="checkbox" id="showPlaton" checked/> Платон</label>
-    </div>
-  </div>
-
   <div id="map"></div>
-
-  <div id="footer">
-    <button id="navBtn" class="btn btn-primary">Навигатор (beta)</button>
-    <button id="shareWA" class="btn btn-ghost">WhatsApp</button>
-    <button id="shareG" class="btn btn-ghost">Google Maps</button>
-    <button id="shareY" class="btn btn-ghost">Яндекс.Навигатор</button>
-    <span class="mute">Маршрутизация: OSRM demo (steps) | Геокодинг: Nominatim | Объезд: эвристика via-точками</span>
+  <div class="controls" id="controls">
+    <label>
+      Откуда
+      <input id="from" type="text" placeholder="Адрес или широта,долгота" autocomplete="off" />
+    </label>
+    <label>
+      Куда
+      <input id="to" type="text" placeholder="Адрес или широта,долгота" autocomplete="off" />
+    </label>
+    <button id="routeBtn" type="button">Маршрут</button>
   </div>
-</div>
+  <div class="legend">
+    <div class="title">Условные обозначения</div>
+    <div class="legend-item"><span class="legend-dot red"></span> Весовые рамки (круг 500 м)</div>
+    <div class="legend-item"><span class="legend-dot orange"></span> Пункты «Платон» (круг 300 м)</div>
+    <div class="legend-item"><span class="legend-line"></span> Маршрут</div>
+  </div>
+  <script>
+    (function() {
+      const state = {
+        map: null,
+        routeLine: null,
+        routeStart: null,
+        routeEnd: null,
+        weightLayer: [],
+        platonLayer: []
+      };
 
-<div class="legend">
-  <b>Условные обозначения</b>
-  <div>● красный — весовые рамки (буфер 500 м)</div>
-  <div>● оранжевый — Платон (буфер 300 м)</div>
-  <div style="margin-top:6px">Синий — маршрут, зелёный — текущая позиция</div>
-</div>
+      ymaps.ready(init);
 
-<div class="navpanel" id="navpanel">
-  <b>Навигация (beta)</b>
-  <div id="navStep">Ожидание старта…</div>
-  <div class="mute" id="navInfo"></div>
-</div>
+      function init() {
+        state.map = new ymaps.Map('map', {
+          center: [55.751244, 37.618423],
+          zoom: 5,
+          controls: ['zoomControl']
+        }, {
+          suppressMapOpenBlock: true
+        });
 
-<script>
-(function(){
-  // --- Глобальное состояние ---
-  const state = {
-    map: null,
-    routePolyline: null,
-    from: null, to: null,
-    routeCoords: [], // [lat,lon]
-    steps: [],
-    posPlacemark: null, watchId: null, curStepIdx: 0,
-    frames: [], platon: [],
-    framesObjs: [], platonObjs: [],
-    radius: { frames: 500, platon: 300 }
-  };
+        new ymaps.SuggestView('from');
+        new ymaps.SuggestView('to');
 
-  // --- init Yandex map ---
-  ymaps.ready(init);
-  function init(){
-    state.map = new ymaps.Map('map', { center:[55.751244,37.618423], zoom:5, controls:['zoomControl'] });
+        document.getElementById('routeBtn').addEventListener('click', buildRoute);
+        document.getElementById('from').addEventListener('keydown', onEnterSubmit);
+        document.getElementById('to').addEventListener('keydown', onEnterSubmit);
 
-    // UI
-    document.getElementById('routeBtn').onclick = buildRoute;
-    document.getElementById('detourBtn').onclick = smartDetour;
-    document.getElementById('gpxBtn').onclick = exportGPX;
-    document.getElementById('navBtn').onclick = startNavigator;
-    document.getElementById('shareWA').onclick = shareWA;
-    document.getElementById('shareG').onclick = ()=>{ const u=buildGoogleLink(); if(u) window.open(u,'_blank'); };
-    document.getElementById('shareY').onclick = ()=>{ const u=buildYandexLink(); if(u) window.open(u,'_blank'); };
-    document.getElementById('showFrames').onchange = (e)=> toggleLayer('frames', e.target.checked);
-    document.getElementById('showPlaton').onchange = (e)=> toggleLayer('platon', e.target.checked);
+        loadGeoJson('weigh_frames.geojson', {
+          color: '#ff3b30',
+          fillColor: 'rgba(255, 59, 48, 0.15)',
+          defaultRadius: 500,
+          collection: state.weightLayer
+        });
+        loadGeoJson('platon.geojson', {
+          color: '#ff9500',
+          fillColor: 'rgba(255, 149, 0, 0.15)',
+          defaultRadius: 300,
+          collection: state.platonLayer
+        });
+      }
 
-    // загрузим GeoJSON слои
-    loadGeo();
-  }
-
-  // --- утилиты ---
-  function parseLatLon(s){
-    const m = String(s||'').trim().match(/(-?\d+(?:\.\d+)?),\s*(-?\d+(?:\.\d+)?)/);
-    return m ? [parseFloat(m[1]), parseFloat(m[2])] : null; // lat, lon
-  }
-  async function geocode(q){
-    const p = parseLatLon(q); if (p) return p;
-    const url = 'https://nominatim.openstreetmap.org/search?format=json&q='+encodeURIComponent(q);
-    const r = await fetch(url, {headers:{'Accept-Language':'ru'}});
-    const js = await r.json(); if (!js.length) throw new Error('Адрес не найден');
-    return [parseFloat(js[0].lat), parseFloat(js[0].lon)];
-  }
-  function toRad(v){return v*Math.PI/180;}
-  function haversine(a,b){
-    const R=6378137, dLat=toRad(b.lat-a.lat), dLon=toRad(b.lon-a.lon);
-    const sa=Math.sin(dLat/2)**2 + Math.cos(toRad(a.lat))*Math.cos(toRad(b.lat))*Math.sin(dLon/2)**2;
-    return 2*R*Math.asin(sa**0.5);
-  }
-  function mercX(lon, refLat){ return lon*Math.PI/180*6378137*Math.cos(refLat*Math.PI/180); }
-  function mercY(lat){ return lat*Math.PI/180*6378137; }
-  function segmentIntersectsCircle(a,b,c,r){
-    const ref = c.lat, Ax=mercX(a.lon,ref), Ay=mercY(a.lat), Bx=mercX(b.lon,ref), By=mercY(b.lat), Cx=mercX(c.lon,ref), Cy=mercY(c.lat);
-    const vx=Bx-Ax, vy=By-Ay, wx=Cx-Ax, wy=Cy-Ay;
-    const vv=vx*vx+vy*vy||1, t=Math.max(0,Math.min(1,(wx*vx+wy*vy)/vv));
-    const px=Ax+t*vx, py=Ay+t*vy;
-    const dist=Math.hypot(px-Cx, py-Cy);
-    return dist<=r;
-  }
-  function detourPoint(a,b,c,r){
-    const ref=c.lat, Ax=mercX(a.lon,ref), Ay=mercY(a.lat), Bx=mercX(b.lon,ref), By=mercY(b.lat), Cx=mercX(c.lon,ref), Cy=mercY(c.lat);
-    const vx=Bx-Ax, vy=By-Ay, len=Math.hypot(vx,vy)||1, nx=-vy/len, ny=vx/len;
-    const px=Cx+nx*r, py=Cy+ny*r;
-    const lon = px/(6378137*Math.cos(ref*Math.PI/180))*180/Math.PI;
-    const lat = py/6378137*180/Math.PI;
-    return {lat,lon};
-  }
-  function simplifyWaypoints(pts,minDist){
-    if (pts.length<=2) return pts;
-    const out=[pts[0]];
-    for(let i=1;i<pts.length-1;i++){
-      const prev={lon:out[out.length-1][0],lat:out[out.length-1][1]};
-      const cur={lon:pts[i][0],lat:pts[i][1]};
-      if (haversine(prev,cur)>=minDist) out.push(pts[i]);
-    }
-    out.push(pts[pts.length-1]);
-    if (out.length>8){
-      const step=Math.ceil(out.length/8), shr=[out[0]];
-      for(let i=1;i<out.length-1;i+=step) shr.push(out[i]);
-      shr.push(out[out.length-1]); return shr;
-    }
-    return out;
-  }
-
-  // --- загрузка GeoJSON ---
-  async function loadGeo(){
-    try {
-      const wf = await (await fetch('weigh_frames.geojson')).json();
-      state.frames = (wf.features||[]).map(f=>({
-        lon:f.geometry.coordinates[0], lat:f.geometry.coordinates[1],
-        name:f.properties?.name||f.properties?.id||'Весовой контроль',
-        note:f.properties?.note, radius:f.properties?.radius_m||state.radius.frames
-      }));
-    } catch(e){}
-    try {
-      const pl = await (await fetch('platon.geojson')).json();
-      state.platon = (pl.features||[]).map(f=>({
-        lon:f.geometry.coordinates[0], lat:f.geometry.coordinates[1],
-        name:f.properties?.name||f.properties?.id||'Платон',
-        note:f.properties?.note, radius:f.properties?.radius_m||state.radius.platon
-      }));
-    } catch(e){}
-    drawPoints();
-  }
-  function drawPoints(){
-    // очистим старые
-    state.framesObjs.forEach(o=>state.map.geoObjects.remove(o));
-    state.platonObjs.forEach(o=>state.map.geoObjects.remove(o));
-    state.framesObjs=[]; state.platonObjs=[];
-    // рамки
-    state.frames.forEach(p=>{
-      const pm = new ymaps.Placemark([p.lat,p.lon], {balloonContent:`<b>${p.name}</b>${p.note?'<br/>'+p.note:''}`},
-        {preset:'islands#redDotIcon'});
-      const circle = new ymaps.Circle([[p.lat,p.lon], p.radius], {}, {fillOpacity:0.15, fillColor:'#dd0000', strokeColor:'#dd0000', strokeOpacity:0.45});
-      state.map.geoObjects.add(pm); state.map.geoObjects.add(circle);
-      state.framesObjs.push(pm,circle);
-    });
-    // платон
-    state.platon.forEach(p=>{
-      const pm = new ymaps.Placemark([p.lat,p.lon], {balloonContent:`<b>${p.name}</b>${p.note?'<br/>'+p.note:''}`},
-        {preset:'islands#orangeDotIcon'});
-      const circle = new ymaps.Circle([[p.lat,p.lon], p.radius], {}, {fillOpacity:0.15, fillColor:'#f29900', strokeColor:'#f29900', strokeOpacity:0.45});
-      state.map.geoObjects.add(pm); state.map.geoObjects.add(circle);
-      state.platonObjs.push(pm,circle);
-    });
-  }
-  function toggleLayer(kind, on){
-    const arr = kind==='frames' ? state.framesObjs : state.platonObjs;
-    arr.forEach(o=>{
-      if (on) state.map.geoObjects.add(o);
-      else state.map.geoObjects.remove(o);
-    });
-  }
-
-  // --- маршрутизация OSRM ---
-  async function buildRoute(){
-    const fromInput=document.getElementById('from').value.trim();
-    const toInput=document.getElementById('to').value.trim();
-    if (!fromInput||!toInput) { alert('Заполни Откуда и Куда'); return; }
-    const [flat,flon] = await geocode(fromInput);
-    const [tlat,tlon] = await geocode(toInput);
-    state.from=[flat,flon]; state.to=[tlat,tlon];
-    await requestRoute([[flon,flat],[tlon,tlat]]);
-  }
-  async function requestRoute(lonLatPairs){
-    const coords = lonLatPairs.map(p=>p.join(',')).join(';');
-    const url = `https://router.project-osrm.org/route/v1/driving/${coords}?overview=full&geometries=geojson&steps=true`;
-    const r = await fetch(url); const js = await r.json();
-    if (!js.routes?.length) { alert('Маршрут не найден'); return; }
-    const rt = js.routes[0];
-    state.routeCoords = rt.geometry.coordinates.map(([lon,lat])=>[lat,lon]); // to [lat,lon]
-    state.steps = (rt.legs||[]).flatMap(l=>l.steps||[]);
-    drawRoute();
-  }
-  function drawRoute(){
-    if (state.routePolyline){ state.map.geoObjects.remove(state.routePolyline); state.routePolyline=null; }
-    state.routePolyline = new ymaps.Polyline(state.routeCoords, {}, { strokeColor:'#2979ff', strokeWidth:4, strokeOpacity:0.9 });
-    state.map.geoObjects.add(state.routePolyline);
-    const bounds = ymaps.geoQuery(state.routePolyline).getBounds();
-    if (bounds) state.map.setBounds(bounds, {checkZoomRange:true, zoomMargin:40});
-  }
-
-  // --- ИИ-объезд (эвристика via-точек) ---
-  async function smartDetour(){
-    if (!state.from||!state.to||!state.routeCoords.length){ alert('Сначала построй маршрут'); return; }
-    const circles = []
-      .concat(state.frames.map(p=>({center:{lat:p.lat,lon:p.lon}, radius:p.radius})))
-      .concat(state.platon.map(p=>({center:{lat:p.lat,lon:p.lon}, radius:p.radius})));
-    const line = state.routeCoords.map(([lat,lon])=>({lat,lon}));
-    let wps = [[state.from[1],state.from[0]]]; // lon,lat
-    for (let i=0;i<line.length-1;i++){
-      const a=line[i], b=line[i+1];
-      for (const c of circles){
-        if (segmentIntersectsCircle(a,b,c.center,c.radius)){
-          const det = detourPoint(a,b,c.center,c.radius+150);
-          wps.push([det.lon,det.lat]);
+      function onEnterSubmit(event) {
+        if (event.key === 'Enter') {
+          event.preventDefault();
+          buildRoute();
         }
       }
-    }
-    wps.push([state.to[1],state.to[0]]);
-    wps = simplifyWaypoints(wps, 200);
-    await requestRoute(wps);
-  }
 
-  // --- навигатор (beta) ---
-  document.addEventListener('visibilitychange', ()=>{ if (document.hidden && state.watchId) navigator.geolocation.clearWatch(state.watchId); });
-  function startNavigator(){
-    if (!state.routeCoords.length || !state.steps.length){ alert('Сначала построй маршрут'); return; }
-    document.getElementById('navpanel').style.display='block';
-    speak('Навигация запущена');
-    if (state.watchId) navigator.geolocation.clearWatch(state.watchId);
-    state.watchId = navigator.geolocation.watchPosition(onPos, ()=>{}, { enableHighAccuracy:true, maximumAge:2000, timeout:8000 });
-  }
-  function onPos(pos){
-    const lat=pos.coords.latitude, lon=pos.coords.longitude;
-    if (!state.posPlacemark){
-      state.posPlacemark = new ymaps.Placemark([lat,lon], {}, {preset:'islands#darkGreenCircleDotIcon'});
-      state.map.geoObjects.add(state.posPlacemark);
-    } else state.posPlacemark.geometry.setCoordinates([lat,lon]);
-    advanceStep([lat,lon]);
-  }
-  function advanceStep([lat,lon]){
-    if (!state.steps.length) return;
-    let idx=state.curStepIdx, cur={lat,lon}, minD=1e12, minI=idx;
-    for (let i=idx;i<Math.min(idx+5,state.steps.length);i++){
-      const s=state.steps[i]; const [slon,slat]=s.maneuver.location;
-      const d=haversine(cur,{lat:slat,lon:slon}); if(d<minD){minD=d;minI=i;}
-    }
-    state.curStepIdx=minI;
-    const step=state.steps[minI]; const [mlon,mlat]=step.maneuver.location;
-    const dTo=haversine(cur,{lat:mlat,lon:mlon});
-    const text=humanizeStep(step);
-    document.getElementById('navStep').textContent=text;
-    document.getElementById('navInfo').textContent=`До манёвра: ${Math.round(dTo)} м`;
-    if (dTo<60){ speak(text); state.curStepIdx=Math.min(state.curStepIdx+1,state.steps.length-1); }
-  }
-  function humanizeStep(step){
-    const t=step.maneuver.type||'move', m=step.maneuver.modifier||'';
-    if (t==='arrive') return 'Прибытие в пункт назначения';
-    if (t==='depart') return 'Начало движения';
-    if (t==='turn'){ if(m==='right')return'Поверни направо'; if(m==='left')return'Поверни налево'; return 'Поверни'; }
-    if (t==='roundabout') return 'Круговое движение, держись направления';
-    if (t==='merge') return 'Перестройся на соседнюю полосу';
-    if (t==='on ramp') return 'Съезд направо';
-    if (t==='off ramp') return 'Съезд налево';
-    if (t==='fork'){ if(m==='right')return'Держись правее'; if(m==='left')return'Держись левее'; return'Держись направления'; }
-    return 'Держись текущего маршрута';
-  }
-  function speak(text){ try{ const u=new SpeechSynthesisUtterance(text); u.lang='ru-RU'; speechSynthesis.cancel(); speechSynthesis.speak(u);}catch(e){} }
+      function parseLatLon(value) {
+        if (!value) return null;
+        const match = value.trim().match(/^\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*$/);
+        if (!match) return null;
+        const lat = parseFloat(match[1]);
+        const lon = parseFloat(match[2]);
+        if (!isFinite(lat) || !isFinite(lon)) return null;
+        if (Math.abs(lat) > 90 || Math.abs(lon) > 180) return null;
+        return [lat, lon];
+      }
 
-  // --- GPX экспорт ---
-  function exportGPX(){
-    if (!state.routeCoords.length){ alert('Сначала построй маршрут'); return; }
-    const trkpts = state.routeCoords.map(([lat,lon])=>`<trkpt lat="${lat.toFixed(6)}" lon="${lon.toFixed(6)}"></trkpt>`).join('\n');
-    const gpx = `<?xml version="1.0" encoding="UTF-8"?>
-<gpx version="1.1" creator="truck-nav" xmlns="http://www.topografix.com/GPX/1/1">
-<trk><name>truck route</name><trkseg>
-${trkpts}
-</trkseg></trk></gpx>`;
-    const blob = new Blob([gpx], {type:'application/gpx+xml'});
-    const a=document.createElement('a'); a.href=URL.createObjectURL(blob); a.download='truck_route.gpx'; a.click(); URL.revokeObjectURL(a.href);
-  }
+      function geocodeInput(value) {
+        const coords = parseLatLon(value);
+        if (coords) {
+          return Promise.resolve(coords);
+        }
+        return ymaps.geocode(value, { results: 1 }).then(function(res) {
+          const first = res.geoObjects.get(0);
+          if (!first) {
+            throw new Error('Адрес не найден: ' + value);
+          }
+          return first.geometry.getCoordinates();
+        });
+      }
 
-  // --- Шаринг и ссылки ---
-  function pickWaypoints(coords,n){
-    const step=Math.max(1,Math.floor(coords.length/(n+2))); const arr=[];
-    for (let i=step;i<coords.length-1 && arr.length<n;i+=step) arr.push(coords[i]);
-    return arr;
-  }
-  function buildGoogleLink(){
-    if (!state.routeCoords.length) return null;
-    const o=state.routeCoords[0], d=state.routeCoords[state.routeCoords.length-1];
-    const wp=pickWaypoints(state.routeCoords,6).map(p=>`${p[0]},${p[1]}`).join('|');
-    let url=`https://www.google.com/maps/dir/?api=1&origin=${o[0]},${o[1]}&destination=${d[0]},${d[1]}&travelmode=driving`;
-    if (wp) url+=`&waypoints=${encodeURIComponent(wp)}`; return url;
-  }
-  function buildYandexLink(){
-    if (!state.routeCoords.length) return null;
-    const o=state.routeCoords[0], d=state.routeCoords[state.routeCoords.length-1];
-    const picks=pickWaypoints(state.routeCoords,6);
-    const rtext=[o].concat(picks).concat([d]).map(p=>`${p[0]},${p[1]}`).join('~');
-    return `https://yandex.ru/maps/?rtext=${encodeURIComponent(rtext)}&rtt=auto`;
-  }
-  function shareWA(){
-    const g=buildGoogleLink(), y=buildYandexLink();
-    if (!g||!y){ alert('Сначала построй маршрут'); return; }
-    const text=`Маршрут для фуры (2 ссылки):%0AGoogle: ${g}%0AЯндекс: ${y}`;
-    window.open(`https://wa.me/?text=${text}`,'_blank');
-  }
+      async function buildRoute() {
+        const fromInput = document.getElementById('from').value.trim();
+        const toInput = document.getElementById('to').value.trim();
 
-  // expose some for handlers
-  window.exportGPX = exportGPX;
-})();
-</script>
+        if (!fromInput || !toInput) {
+          alert('Укажите оба адреса.');
+          return;
+        }
+
+        try {
+          const [fromCoords, toCoords] = await Promise.all([
+            geocodeInput(fromInput),
+            geocodeInput(toInput)
+          ]);
+
+          await requestRoute(fromCoords, toCoords);
+        } catch (error) {
+          console.error(error);
+          alert(error.message || 'Не удалось построить маршрут.');
+        }
+      }
+
+      async function requestRoute(fromCoords, toCoords) {
+        const url = buildOsrmUrl(fromCoords, toCoords);
+        const response = await fetch(url);
+        if (!response.ok) {
+          throw new Error('Маршрутный сервис недоступен.');
+        }
+        const data = await response.json();
+        if (!data.routes || !data.routes.length) {
+          throw new Error('Маршрут не найден.');
+        }
+
+        const geometry = data.routes[0].geometry.coordinates;
+        const path = geometry.map(function(coord) {
+          return [coord[1], coord[0]];
+        });
+
+        drawRoute(path, fromCoords, toCoords);
+      }
+
+      function buildOsrmUrl(fromCoords, toCoords) {
+        const fromLonLat = [fromCoords[1], fromCoords[0]].join(',');
+        const toLonLat = [toCoords[1], toCoords[0]].join(',');
+        return 'https://router.project-osrm.org/route/v1/driving/' + fromLonLat + ';' + toLonLat + '?overview=full&geometries=geojson';
+      }
+
+      function drawRoute(path, fromCoords, toCoords) {
+        if (state.routeLine) {
+          state.map.geoObjects.remove(state.routeLine);
+        }
+        if (state.routeStart) {
+          state.map.geoObjects.remove(state.routeStart);
+          state.map.geoObjects.remove(state.routeEnd);
+        }
+
+        state.routeLine = new ymaps.Polyline(path, {}, {
+          strokeColor: '#0066ff',
+          strokeWidth: 5,
+          strokeOpacity: 0.9
+        });
+
+        state.routeStart = new ymaps.Placemark(fromCoords, { iconCaption: 'Старт' }, { preset: 'islands#blueCircleIcon' });
+        state.routeEnd = new ymaps.Placemark(toCoords, { iconCaption: 'Финиш' }, { preset: 'islands#blueCircleIcon' });
+
+        state.map.geoObjects.add(state.routeLine);
+        state.map.geoObjects.add(state.routeStart);
+        state.map.geoObjects.add(state.routeEnd);
+
+        const bounds = state.routeLine.geometry.getBounds();
+        if (bounds) {
+          state.map.setBounds(bounds, { checkZoomRange: true, zoomMargin: 40 });
+        }
+      }
+
+      async function loadGeoJson(url, options) {
+        try {
+          const response = await fetch(url, { cache: 'no-store' });
+          if (!response.ok) return;
+          const data = await response.json();
+          if (!data.features) return;
+          data.features.forEach(function(feature) {
+            if (!feature.geometry || feature.geometry.type !== 'Point') return;
+            const coords = feature.geometry.coordinates;
+            const center = [coords[1], coords[0]];
+            const props = feature.properties || {};
+            const radius = Number(props.radius_m) || options.defaultRadius;
+            const balloon = formatBalloon(props);
+
+            const placemark = new ymaps.Placemark(center, {
+              balloonContent: balloon,
+              hintContent: props.name || ''
+            }, {
+              preset: 'islands#dotIcon',
+              iconColor: options.color,
+              zIndex: 1500
+            });
+            const circle = new ymaps.Circle([center, radius], {
+              balloonContent: balloon,
+              hintContent: props.name || ''
+            }, {
+              fillColor: options.fillColor,
+              strokeColor: options.color,
+              strokeOpacity: 0.6,
+              fillOpacity: 0.4,
+              strokeWidth: 2,
+              zIndex: 1200
+            });
+
+            state.map.geoObjects.add(circle);
+            state.map.geoObjects.add(placemark);
+
+            options.collection.push({ placemark, circle });
+          });
+        } catch (error) {
+          console.warn('Не удалось загрузить ' + url, error);
+        }
+      }
+
+      function formatBalloon(props) {
+        const parts = [];
+        if (props.name) {
+          parts.push('<strong>' + escapeHtml(props.name) + '</strong>');
+        }
+        if (props.road || props.km) {
+          const road = props.road ? escapeHtml(props.road) : '';
+          const km = props.km ? ' ' + escapeHtml(props.km) : '';
+          parts.push(road + km);
+        }
+        if (props.note) {
+          parts.push(escapeHtml(props.note));
+        }
+        return parts.join('<br>');
+      }
+
+      function escapeHtml(text) {
+        return String(text)
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/"/g, '&quot;')
+          .replace(/'/g, '&#39;');
+      }
+    })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- rebuild the GitHub Pages index with a full-screen Yandex Maps v2.1 setup
- add address inputs with suggest support and routing via OSRM including lat/lon parsing
- load weigh station and Platon GeoJSON overlays with circles and informative balloons

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de817dc164832386b6703765090f2b